### PR TITLE
Replace filters with jinja tests

### DIFF
--- a/tasks/sanity_checks.yml
+++ b/tasks/sanity_checks.yml
@@ -3,7 +3,7 @@
   assert:
     that:
       - ansible_distribution in ["CentOS", "RedHat"]
-      - ansible_distribution_version | version_compare('7.4', '>=')
+      - ansible_distribution_version is version_compare('7.4', '>=')
 
 - name: Sanity check of docker_storage_driver variable
   assert:


### PR DESCRIPTION
Changes:
- Use jinja tests instead of filters. Filters for tests are deprecated since Ansible 2.5+.